### PR TITLE
simplify init/share, auto-init on share:

### DIFF
--- a/lib/dat/swarmManager.js
+++ b/lib/dat/swarmManager.js
@@ -241,7 +241,7 @@ class SwarmManager extends EventEmitter {
         })
         continue
       }
-      await this.initDat(dir)
+
       try {
         const results = await this.shareDir(dir)
         shared.results.push({ dir, ...results })
@@ -259,16 +259,10 @@ class SwarmManager extends EventEmitter {
    */
   async initDat(directory) {
     debug(`Init DAT: ${directory}`)
-    const actualPath = this.actualDirPath(directory)
-    if (this.isActiveDir(actualPath)) {
-      const discoveryKey = this.getDiscoveryKeyForDir(actualPath)
-      return {
-        discoveryKey,
-        datKey: this.getDat(discoveryKey).key('hex'),
-      }
-    }
-    // we maybe know about this dat but have not init it or are sharing it
-    return this._initDat(actualPath)
+
+    const { discoveryKey, datKey } = await this._loadDat(directory)
+
+    return { discoveryKey, datKey }
   }
 
   /**
@@ -277,17 +271,16 @@ class SwarmManager extends EventEmitter {
    * @return {Promise<{discoveryKey: string, datKey: string}>} - Information about the dat
    */
   async shareDir(directory) {
-    const actualPath = this.actualDirPath(directory)
-    if (!this.isActiveDir(actualPath)) {
-      throw new Error(`Cannot share ${directory}. It is not initialized`)
+
+    const { discoveryKey, datKey, dat } = await this._loadDat(directory)
+
+    await dat.importFiles()
+
+    if (!dat.sharing()) {
+      this._shareDat(dat, discoveryKey, datKey)
     }
-    const discoveryKey = this.getDiscoveryKeyForDir(actualPath)
-    const existingDat = this.getDat(discoveryKey)
-    await existingDat.importFiles()
-    if (!existingDat.sharing()) {
-      this._shareDat(existingDat, discoveryKey)
-    }
-    return { discoveryKey, datKey: existingDat.key('hex') }
+
+    return { discoveryKey, datKey }
   }
 
   /**
@@ -380,18 +373,30 @@ class SwarmManager extends EventEmitter {
   }
 
   /**
-   * @desc Initialize a dat
+   * @desc Initialize or load cached dat
    * @param {string} dir - The full path to the directory to initialize the dat in
    * @return {Promise<{discoveryKey: string, datKey: string}>}
    * @private
    */
-  async _initDat(dir) {
-    const dat = await DatWrapper.from(dir)
-    await dat.importFiles()
-    const discoveryKey = dat.discoveryKey('hex')
-    const datKey = dat.key('hex')
-    this._markDatAsActive(dir, discoveryKey, dat)
-    return { discoveryKey, datKey }
+  async _loadDat(dir) {
+    dir = this.actualDirPath(dir)
+
+    if (this.isActiveDir(dir)) {
+      const discoveryKey = this.getDiscoveryKeyForDir(dir)
+      const dat = this.getDat(discoveryKey)
+      const datKey = dat.key('hex')
+
+      return { discoveryKey, datKey, dat }
+    } else {
+
+      const dat = await DatWrapper.from(dir)
+      const discoveryKey = dat.discoveryKey('hex')
+      const datKey = dat.key('hex')
+
+      this._markDatAsActive(dir, discoveryKey, dat)
+
+      return { discoveryKey, datKey, dat }
+    }
   }
 
   /**
@@ -464,12 +469,18 @@ class SwarmManager extends EventEmitter {
    * @desc Start sharing the supplied dat by having it join the swarm
    * @param {DatWrapper} dat - The dat to have join the swarm
    * @param {string?} [dk] - The dat's discovery key
+   * @param {string?} [datKey] - The dat key
    * @private
    */
-  _shareDat(dat, dk) {
+  _shareDat(dat, dk, datKey) {
     if (!dk) {
       dk = dat.discoveryKey('hex')
     }
+    if (!datKey) {
+      datKey = dat.key('hex')
+    }
+    debug(`Sharing DAT: ${datKey}`)
+
     dat.joinSwarm(this._swarm).then(() => {
       this.emit('shared-dat', dk)
       debug(`Added discoveryKey to swarm: ${dk}`)


### PR DESCRIPTION
- add _loadDat() which inits dat if not stored, otherwise uses cached version
- /init calls _loadDat() only
- /share calls _loadDat(), then starts sharing